### PR TITLE
perf(statuscolumn): propose some potential bugs and performance improvements for statuscolumn.

### DIFF
--- a/lua/ui/statuscolumn/init.lua
+++ b/lua/ui/statuscolumn/init.lua
@@ -1,20 +1,52 @@
 local M = {}
+local utils = require("ui.utils") -- Import the utils module
 
 local reset_cache = function(bufnr)
 	bufnr = bufnr or vim.api.nvim_get_current_buf()
 	if vim.api.nvim_buf_is_valid(bufnr) then
-		vim.api.nvim_buf_set_var(bufnr, "_extmark_cache", {})
+		-- Resetting to nil is better as table comparison `extmark_cache[lnum]`
+		-- in utils.lua will error if extmark_cache is {} but lnum is not a key.
+		-- Setting to nil ensures it's correctly re-initialized.
+		vim.api.nvim_buf_set_var(bufnr, "_extmark_cache", nil)
+	end
+end
+
+local function debounce(fn, ms)
+	local timer = nil -- This will now store the timer object returned by utils.timer_fn
+	return function(...)
+		local call_args = { ... }
+		-- utils.timer_fn handles stopping the previous timer if 'timer' is passed to it.
+		timer = utils.timer_fn(timer, ms, function()
+			-- timer is implicitly nil here by utils.timer_fn design after callback
+			-- or we can set timer = nil if we want to be explicit,
+			-- though utils.timer_fn will create a new one next time regardless.
+			fn(unpack(call_args))
+		end)
 	end
 end
 
 M.setup = function()
 	vim.api.nvim_create_augroup("StatusColumnRefresh", { clear = true })
+
+	local immediate_refresh_callback = function(args)
+		reset_cache(args.buf)
+		vim.schedule(function()
+			vim.cmd([[redrawstatus]])
+		end)
+	end
+
+	local debounced_refresh_callback = debounce(function(args)
+		reset_cache(args.buf)
+		vim.schedule(function()
+			vim.cmd([[redrawstatus]])
+		end)
+	end, 200) -- 200ms debounce delay
+
+	-- Events that should trigger immediate refresh
 	vim.api.nvim_create_autocmd(
 		{
 			"BufWrite",
 			"BufEnter",
-			"TextChanged",
-			"TextChangedI",
 			"FocusGained",
 			"LspAttach",
 			"DiagnosticChanged",
@@ -22,14 +54,22 @@ M.setup = function()
 		},
 		{
 			group = "StatusColumnRefresh",
-			callback = function(args)
-				reset_cache(args.buf)
-				vim.schedule(function()
-					vim.cmd([[redrawstatus]])
-				end)
-			end,
+			callback = immediate_refresh_callback,
 		}
 	)
+
+	-- Events that should trigger debounced refresh
+	vim.api.nvim_create_autocmd(
+		{
+			"TextChanged",
+			"TextChangedI",
+		},
+		{
+			group = "StatusColumnRefresh",
+			callback = debounced_refresh_callback,
+		}
+	)
+
 	vim.api.nvim_set_option_value("statuscolumn", "%!v:lua.require('ui.statuscolumn.utils').set_statuscolumn()", {})
 end
 

--- a/lua/ui/statuscolumn/utils.lua
+++ b/lua/ui/statuscolumn/utils.lua
@@ -24,6 +24,10 @@ end
 
 _G.statuscolumn_click_fold_callback = function()
 	local pos = vim.fn.getmousepos()
+	if not vim.api.nvim_win_is_valid(pos.winid) then
+		vim.notify("Error: Invalid window ID in statuscolumn_click_fold_callback", vim.log.levels.ERROR)
+		return
+	end
 	vim.api.nvim_win_set_cursor(pos.winid, { pos.line, 1 })
 	vim.api.nvim_win_call(pos.winid, function()
 		if vim.fn.foldlevel(pos.line) > 0 then
@@ -33,13 +37,18 @@ _G.statuscolumn_click_fold_callback = function()
 end
 
 M.get_extmark_info = function(bufnr, lnum)
+	local extmark_cache = vim.b[bufnr]._extmark_cache
 
-	local extmark_cache = vim.b[bufnr]._extmark_cache or {}
-
-	if #extmark_cache > 0 and extmark_cache[lnum] ~= vim.NIL then -- setting a bufvar populates the missing indices with vim.NIL
+	-- Check if cache is valid (not Lua nil and not vim.NIL) and has data for the current line.
+	-- vim.NIL is a userdata that represents a variable explicitly set to nil by API.
+	if extmark_cache ~= nil and extmark_cache ~= vim.NIL and extmark_cache[lnum] then
 		return extmark_cache
 	end
 
+	-- If cache is nil, vim.NIL, or doesn't have data for this specific line, rebuild it.
+	-- Initialize signs table. If extmark_cache was vim.NIL or nil, this is a fresh build.
+	-- If extmark_cache was a table but missed lnum, we are also doing a fresh build for simplicity,
+	-- as per original logic before vim.NIL handling.
 	local signs = {}
 	local extmarks = vim.api.nvim_buf_get_extmarks(bufnr, -1, 0, -1, { details = true, type = "sign" })
 
@@ -59,7 +68,9 @@ M.get_extmark_info = function(bufnr, lnum)
 		})
 	end
 
-	vim.api.nvim_buf_set_var(bufnr, "_extmark_cache", signs)
+	-- Store the entirely rebuilt signs table in the cache.
+	-- This is simpler than trying to update incrementally and ensures freshness.
+	vim.b[bufnr]._extmark_cache = signs
 
 	return signs
 end
@@ -83,17 +94,17 @@ M.get_diagnostic_sign = function(extmarks, bufnr)
 end
 
 M.right_sign = function (win, lnum, extmarks, bufnr)
-	local str = M.get_diagnostic_sign(extmarks, bufnr)
-	if str ~= "" then
-		return string.format("%%3.3(%s%%)", str)
+	local diagnostic_sign_str = M.get_diagnostic_sign(extmarks, bufnr)
+	if diagnostic_sign_str ~= "" then
+		return string.format("%%3.3(%s%%)", diagnostic_sign_str)
 	end
 
-	str = M.get_folds(win, lnum)
-	if str ~= "" then
-		return string.format("%%3.3(%s%%)", str)
+	local fold_str = M.get_folds(win, lnum)
+	if fold_str ~= "" then
+		return string.format("%%3.3(%s%%)", fold_str)
 	end
 
-	return "%3.3(%)"
+	return "%3.3(%)" -- Returns a 3-character wide empty string for alignment
 end
 
 M.generate_extmark_string = function(win, lnum)
@@ -101,11 +112,19 @@ M.generate_extmark_string = function(win, lnum)
 		return ""
 	end
 	local bufnr = vim.api.nvim_win_get_buf(win)
-	local extmarks = M.get_extmark_info(bufnr, lnum)[lnum] or {}
+	local all_extmarks_for_buffer = M.get_extmark_info(bufnr, lnum)
+	local extmarks_for_line = all_extmarks_for_buffer[lnum]
+
+	-- If extmarks_for_line is nil (no entry for this line) or vim.NIL (explicitly set to nil via API),
+	-- default to an empty table to prevent errors in subsequent functions expecting a table.
+	if extmarks_for_line == nil or extmarks_for_line == vim.NIL then
+		extmarks_for_line = {}
+	end
+
 	local str = string.format(
 		"%s%%l%s",
-		M.get_git_sign(extmarks, bufnr),
-		M.right_sign(win, lnum, extmarks, bufnr)
+		M.get_git_sign(extmarks_for_line, bufnr),
+		M.right_sign(win, lnum, extmarks_for_line, bufnr)
 	)
 	return str
 end


### PR DESCRIPTION
- Modified `generate_extmark_string` in `lua/ui/statuscolumn/utils.lua` to ensure that the extmarks list for a specific line defaults to an empty table if it's `nil` or `vim.NIL`. This prevents errors in functions like `get_git_sign` that expect a table for `ipairs`.

This commit also includes previous fixes and optimizations:
- Fixed `get_extmark_info` to correctly handle `vim.NIL` for the main cache variable.
- Improved caching logic in `get_extmark_info`.
- Added error handling for `statuscolumn_click_fold_callback`.
- Implemented debouncing for `TextChanged` and `TextChangedI` autocommands.
- Refactored debounce logic to use `timer_fn` from `ui.utils`.
- Adjusted `reset_cache` to use `nil` for clearer cache state.
- Minor clarification in `right_sign`.