### PR TITLE
feat(tabline): append parent directory name to buffer names in case of duplicate buffer names in tabline

### DIFF
--- a/lua/config/lsp/lsputils.lua
+++ b/lua/config/lsp/lsputils.lua
@@ -163,7 +163,7 @@ end
 ---@param fun function?
 local on_attach = function(client, bufnr)
 	if client.server_capabilities.inlayHintProvider then
-		vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled())
+		vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled(), { bufnr = bufnr })
 	end
 
 	vim.keymap.set(

--- a/lua/plugins/avante.lua
+++ b/lua/plugins/avante.lua
@@ -1,5 +1,6 @@
 local M = {
 	"yetone/avante.nvim",
+	enabled = false,
 	-- if you want to build from source then do `make BUILD_FROM_SOURCE=true`
 	-- ⚠️ must add this setting! ! !
 	build = function()

--- a/lua/plugins/snacks.lua
+++ b/lua/plugins/snacks.lua
@@ -1,6 +1,6 @@
 ---@diagnostic disable: missing-fields
 local P = {
-	"100x65b1111000/snacks.nvim",
+	"folke/snacks.nvim",
 	enabled = true,
 	priority = 999,
 	lazy = false,

--- a/lua/ui/states.lua
+++ b/lua/ui/states.lua
@@ -4,13 +4,14 @@ M.cache = { highlights = {} }
 
 --- *** Tabline Cache ***
 M.tabline_states = {}
+
 M.tabline_states.BufferStates = {
 	ACTIVE = 1,
 	INACTIVE = 2,
 	NONE = 3,
 }
 
-M.tabline_states.tabline_buf_str_max_width = 18
+M.tabline_states.tabline_buf_str_max_width = math.huge
 
 M.tabline_states.cache = {
 	tabline_string = "",
@@ -21,7 +22,7 @@ M.tabline_states.cache = {
 }
 
 M.tabline_states.init_files = {
-	"init.lua",
+	["init.lua"] = true
 }
 
 ---@class Icons
@@ -43,6 +44,7 @@ M.tabline_states.offset = 0
 
 ---@type integer[]
 M.tabline_states.visible_buffers = {}
+M.tabline_states.bufname_count = {}
 
 M.tabline_states.left_overflow_str = ""
 M.tabline_states.right_overflow_str = ""

--- a/lua/ui/tabline/utils.lua
+++ b/lua/ui/tabline/utils.lua
@@ -75,7 +75,7 @@ local function get_buffer_state(bufnr)
 end
 
 local function get_duplicate_bufs()
-	local bufs = states.buffers_list
+	local bufs = states.visible_buffers
 	local bufnames = {}
 	local duplicate_bufs = {}
 	for _, i in ipairs(bufs) do

--- a/lua/ui/tabline/utils.lua
+++ b/lua/ui/tabline/utils.lua
@@ -80,7 +80,7 @@ local function get_buffer_state(bufnr)
 end
 
 local function get_duplicate_bufs()
-	local bufs = states.visible_buffers
+	local bufs = states.buffers_list
 	local bufnames = {}
 	local duplicate_bufs = {}
 	for _, i in ipairs(bufs) do
@@ -96,7 +96,7 @@ local function get_duplicate_bufs()
 	return duplicate_bufs
 end
 
----Processes the buffer name for display.
+---rocesses the buffer name for display.
 ---@param bufnr integer The buffer number.
 ---@return string The processed buffer name.
 local function process_buffer_name(bufnr)
@@ -396,6 +396,7 @@ local function generate_buffer_string(bufnr)
 		right_padding,
 		buf_spec.close_btn
 	)
+	M.update_overflow_info(states.visible_buffers)
 	return buf_string
 end
 

--- a/lua/ui/tabline/utils.lua
+++ b/lua/ui/tabline/utils.lua
@@ -246,7 +246,8 @@ local calculate_buf_space = function(bufs)
 	return length
 end
 
-M.update_overflow_info = function(bufs)
+M.update_overflow_info = function()
+	local bufs = states.buffers_list
 	local left_dist = states.start_idx - 1
 	local right_dist = #bufs - states.end_idx
 	states.left_overflow_str = ""
@@ -528,12 +529,10 @@ M.update_tabline_buffer_info = function()
 		states.buffers_spec = get_buffers_with_specs(states.buffers_list)
 		states.left_overflow_idicator_length = 0
 		states.right_overflow_idicator_length = 0
-		local bufs = states.buffers_list
-		local buf_specs = states.buffers_spec
-		fetch_visible_buffers(bufnr, bufs, buf_specs)
-		M.update_overflow_info(bufs)
-		fetch_visible_buffers(bufnr, bufs, buf_specs) -- overflow indicators might shorten the available width
-		M.update_overflow_info(bufs)
+		fetch_visible_buffers(bufnr, states.buffers_list, states.buffers_spec)
+		M.update_overflow_info()
+		fetch_visible_buffers(bufnr, states.buffers_list, states.buffers_spec) -- overflow indicators might shorten the available width
+		M.update_overflow_info()
 	end)
 end
 


### PR DESCRIPTION
The tabline now appends parent directory name prior to filenames in the bufferline in case, there are two or more buffers with similar names. This helps to easily distinguish files that have same names but are located at different paths.